### PR TITLE
add code of conduct to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,8 @@ Adapted from the [Vox Code of Conduct](http://code-of-conduct.voxmedia.com/?_ga=
 
 #### Revisions/edits log
 
-Jan. 25, 2018: Added “be an ally” in expected behaviors with resource guide. All further revisions will be tracked through Github :) 
+Jan. 25, 2018: Added “be an ally” in expected behaviors with resource guide. All further revisions will be tracked through Github :)
+
+#### This project is licensed under the terms of the MIT license.
+
+This project is open source as a way to transparently share our code of conduct with the community.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# codeofconduct
-Buffer's Employee Code of Conduct
+Buffer is dedicated to creating an inclusive environment for everyone, regardless of race, ethnicity, religion, color, national origin, age, disability (physical or mental), sexual orientation, gender identity, parental status, marital status, and political affiliation as well as gender expression, mental illness, socioeconomic status or background, neuro(a)typicality, or physical appearance. We're united by Buffer's values, and we celebrate our unique differences.
+
+We put forth this code of conduct not because we anticipate bad behavior, but because we believe in the already exceptional level of respect among the team. We believe that articulating our values and accountabilities to one another reinforces that respect and provides us with clear avenues to correct our culture should it ever stray. We commit to enforce and evolve this code as our team grows.
+
+Like our [Buffer values](https://open.buffer.com/buffer-values/), the contents of this code of conduct are concepts we expect teammates to work to apply to their daily lives in and outside of Buffer. Specifically, the code of conduct applies to teammate interactions in various areas of our shared professional lives, including all events hosted by Buffer, shared online spaces (Slack, Discourse, Trello, email, etc.) , social media, pull request feedback, and conferences or other events where we represent Buffer.
+
+
+### Expected behaviors
+
+Every member of the Buffer team is expected to work smart, be considerate of their teammates across the team, and contribute to a collaborative, positive, and healthy environment in which we can all succeed. Specifically:
+
+- **Be supportive of your colleagues**, both proactively and responsively. Offer to help if you see someone struggling or otherwise in need of assistance (taking care not to be patronizing or disrespectful). If someone approaches you looking for help, be generous with your time; if you’re under a deadline, let them know when you will be able to help or direct them to someone else who may be of assistance.
+- **Be inclusive:** Go out of your way and across cultures to include people in team jokes or memes; we want to build an environment free of cliques. Avoid slang or idioms that might not translate across cultures, or be deliberate in explaining them to share our diverse cultures and languages. Speak plainly and avoid acronyms and jargon that not everyone may have an understanding of. [Be an ally to teammates](https://www.betterbrave.com/allies) when you see a need.
+- **Be collaborative.** Involve your teammates in brainstorms, sketching sessions, code reviews, planning documents, and the like. It’s part of our values to share early and ask for feedback often. Don’t succumb to either [impostor syndrome (believing that you don’t deserve to be here) or the Dunning-Kruger Effect (believing you can do no wrong).]((https://open.buffer.com/confidence-humility/)) Recognize that in addition to asking for feedback, you are similarly obligated to give it.
+- **Be generous in both giving and accepting feedback.** Feedback is a natural and important part of our culture. [Good feedback](https://open.buffer.com/how-to-give-receive-feedback-work/) is kind, respectful, clear, and constructive, and focused on goals and values rather than personal preferences. You are expected to give and receive feedback with gratitude and a [growth mindset.](https://blog.bufferapp.com/the-habits-of-successful-people-they-have-a-growth-mindset)
+- **Be respectful toward all time zones.** Embrace habits that are inclusive and productive for team members wherever they are: make liberal use of asynchronous communication tools, document syncs and decisions thoroughly, and pay attention to timezones when scheduling events.
+- **Be kind.** Be polite and friendly in all forms of communication – especially remote communication, where opportunities for misunderstanding are greater. Avoid sarcasm. Tone is hard to decipher online; make liberal use of emoji, GIFs and Bitmoji to aid in communication. Use video hangouts when it makes sense; face-to-face discussion benefits from all kinds of social cues that may go missing in other forms of communication.
+
+
+### Unacceptable behaviors
+
+The Buffer team is committed to providing a welcoming and safe environment for all. Discrimination and harassment are expressly prohibited. Furthermore, any behavior or language that is unwelcoming—whether or not it rises to the level of harassment—is also strongly discouraged.
+
+Additionally, there are a host of behaviors and language common on tech teams which are worth noting as specifically unwelcome:
+
+
+- **No surprise if a teammate isn’t familiar with something:** At Buffer, we believe in the value of a [beginner’s mind.](https://open.buffer.com/no-idea/) It’s always acceptable to say "I don't know" or "I don't understand." All questions are great questions! So please don't act surprised when people aren’t familiar with a tool, person, place or process. This applies to both technical things ("What?! I can't believe you don't know what the stack is!") and non-technical things ("You don't know who DHH is?!").
+- **No well-actually's:** A well-actually happens when someone says something that's almost - but not entirely - correct, and you say, ["well, actually…"](https://open.buffer.com/customer-service-emails-words/) and give a minor correction. We strive to let others save face as part of our values, and most well-actually's aren’t crucial to the overall conversation. If it’s critical to add your correction, use language that leaves room for the idea that you might be wrong or missing some context, too.)
+- **No exclusionary language:** Be careful in the words that you choose, even if it’s as small as choosing “hey, everyone” over [“hey, guys.”](https://open.buffer.com/diversity-mistakes/) Sexist, racist, and other exclusionary jokes are not appropriate and will not be tolerated under any circumstance. Any language that is unwelcoming—whether or not it rises to the level of harassment—is also strongly discouraged.
+- **No subtle -isms:** Much exclusionary behavior takes the form of subtle -isms, or [microaggressions](https://open.buffer.com/inclusive-language-tech/) – small things that make others feel unwelcome. For example, saying ["It's so easy my grandmother could do it"](https://open.buffer.com/diversity-mistakes/) is a subtle -ism with tones of both sexism and ageism. Regardless of intent, these comments can have a significant demeaning impact on teammates. If you see a subtle -ism, you can point it out to the relevant person, either publicly or privately, or you can ask a lead or People Team member to say something. (If you are a third party, and you don't see what could be biased about the comment that was made, feel free to talk to the People Team.)
+
+Please don't say, "Comment X wasn't sexist!" or “That’s not what they meant. You’re being too sensitive.” Similarly, please don't pile on someone who made a mistake. It's not a big deal to mess up – just apologize and move on.
+
+
+### Reporting a problem
+
+These guidelines are ambitious, and we’re not always going to succeed in meeting them. When something goes wrong—whether it’s a microaggression or an instance of harassment—there are a number of things you can do to address the situation with your fellow teammates or with the People Team.
+
+We know that you’ll do your best work if you’re happy and comfortable in your surroundings, so we take concerns about this stuff seriously. Depending on your comfort level and the severity of the situation, here are some things you can do to address it:
+
+
+1. **Address it directly.** If you’re comfortable bringing up the incident with the person who instigated it, DM them or set up a video chat to discuss how it affected you. Be sure to approach these conversations in a forgiving spirit: an angry or tense conversation will not do either of you any good. If you’re unsure how to go about that, try discussing with your lead or with the People Team first—they might have some advice about how to make this conversation happen. If you’re too frustrated to have a direct conversation, there are a number of alternate routes you can take.
+2. **Talk to a peer or mentor.** Your teammates are likely to have personal and professional experience on which to draw that could be of use to you. If you have someone you’re comfortable approaching, reach out and discuss the situation with them. They may be able to advise on how they would handle it, or direct you to someone who can. The flip side of this, of course, is that you should also be available when your colleagues reach out to you.
+3. **Talk to your lead.** Your lead probably knows quite a lot about the dynamics of your team, which makes them a good person to look to for advice. They may also be able to talk directly to the colleague in question if you feel uncomfortable or unsafe doing so yourself. Finally, your manager will be able to help you figure out how to ensure that any conflict with a colleague doesn’t interfere with your work.
+4. **Talk to a member of the People Team.** People Team members are happy to talk to you about the problem and help figure out what steps to take. You can make a report either personally to your lead or to Courtney/Director of People and Jenny/Compliance Manager anonymously using our Google Form. We’re keen to hear concerns about small violations, and also able to help out in situations where more drastic action needs to be taken. In all cases, we will make every effort to stay in clear communication with anyone who reports a problem, maintaining confidentiality whenever possible.
+
+### Taking care of each other
+
+Sometimes, you’ll be a witness to something that seems like it isn’t aligned with our values. Err on the side of caring for your colleagues in situations like these. Even if an incident seems minor, reach out to the person impacted by it to check in. In certain situations, it may even be helpful to speak directly to the person who has violated the code of conduct, a lead, or a member of the People Team directly to voice your concerns.
+
+If you want to speak to a person impacted by an incident or to the person who has violated the code of conduct, but you’re unsure of how to navigate these interactions, try reaching out to Courtney/Director of People or Jenny/Compliance Manager—these conversations are tricky, and we’d like to help you figure out how best to approach them.
+
+### Committing to self-improvement
+
+None of us are perfect: all of us, regardless of our backgrounds, will from time to time fail to live up to our very high standards. What matters isn’t having a perfect track record, but owning up to your mistakes and committing to a clear and persistent effort to improve.
+
+If you are approached as having (consciously or otherwise) acted in a way that might make your teammates feel unwelcome, listen with an open mind and avoid becoming defensive. Remember that if someone offers you feedback, it likely took a great deal of courage for them to do so. The best way to respect that courage is to acknowledge your mistake, apologize, and move on — with a renewed commitment to do better.
+
+That said, repeated or severe violations of this code can and will be addressed by the people and culture team, and can lead to disciplinary actions, including termination.
+
+Adapted from the [Vox Code of Conduct](http://code-of-conduct.voxmedia.com/?_ga=1.62865454.308680892.1455143920), the [Recurse Center’s Social Rules](https://www.recurse.com/manual#sub-sec-social-rules) and the [Hack Code of Conduct.](https://hackcodeofconduct.org/)
+
+
+
+#### Revisions/edits log
+
+Jan. 25, 2018: Added “be an ally” in expected behaviors with resource guide. All further revisions will be tracked through Github :) 


### PR DESCRIPTION
Open source our Code of Conduct! 🎉 

I've made a few small changes from our Paper Doc
1. I removed the link to our anonymous reporting Google Doc so that people who are not Buffer employees can't make reports 😉 

2. I added "All further revisions will be tracked through Github :) " to the bottom of the doc :) I'd love to make sure that whenever we update our Code of Conduct, we also make a PR to this repo to update our README! ✨ 

3. I've added an MIT license at the end of the doc to let others know they are free to reuse parts or all of our CoC :) 